### PR TITLE
Fix node-gyp compiling failure caused by webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     ]
   },
   "devDependencies": {
-    "gh-pages": "^2.0.1"
+    "gh-pages": "^2.0.1",
+    "webpack": "^4.28.3"
   }
 }


### PR DESCRIPTION
**Description**: Incorrect version of webpack installed causes node-gyp to fail during a rebuild. React requires v4.28.3
**Reproduce**: `git clone` then `npm i` 
**Fix**: add `webpack@4.28.3` in `package.json`